### PR TITLE
Fix branch checkout in CentOS script

### DIFF
--- a/tensorflow/centos-6.6/build2.sh
+++ b/tensorflow/centos-6.6/build2.sh
@@ -17,11 +17,10 @@ conda install -c conda-forge keras-applications
 
 cd /
 rm -fr tensorflow/
-git clone --depth 1 "https://github.com/tensorflow/tensorflow.git"
+git clone --depth 1 --branch $TF_VERSION_GIT_TAG "https://github.com/tensorflow/tensorflow.git"
 
 TF_ROOT=/tensorflow
 cd $TF_ROOT
-git checkout $TF_VERSION_GIT_TAG
 
 # Python path options
 export PYTHON_BIN_PATH=$(which python)


### PR DESCRIPTION
I encountered two issues with the CentOS script:

1. `git clone` goes not fetch information about all remote branches and tags, so `git checkout $TF_VERSION_GIT_TAG` fails. This PR fixes this issue (and this is what Ubuntu script already does).

2. Targeting CentOS 6.6 didn't work for me because `devtoolset-4-*` packages are missing. I couldn't figure out how to fix that quick enough, so I changed CentOS version to 7.4. I could then build Tensorflow without any other issues. (https://github.com/hadim/docker-tensorflow-builder/issues/10)