### PR TITLE
Lock Bazel at 0.15.0

### DIFF
--- a/tensorflow/centos-6.6/build2.sh
+++ b/tensorflow/centos-6.6/build2.sh
@@ -6,7 +6,7 @@ gcc --version
 # Install an appropriate Python environment
 conda create --yes -n tensorflow python==$PYTHON_VERSION
 source activate tensorflow
-conda install --yes numpy wheel bazel
+conda install --yes numpy wheel bazel==0.15.0
 conda install --yes -c conda-forge keras-applications
 
 # Compile TensorFlow

--- a/tensorflow/ubuntu-16.04/build.sh
+++ b/tensorflow/ubuntu-16.04/build.sh
@@ -12,7 +12,7 @@ gcc --version
 # Install an appropriate Python environment
 conda create --yes -n tensorflow python==$PYTHON_VERSION
 source activate tensorflow
-conda install --yes numpy wheel bazel
+conda install --yes numpy wheel bazel==0.15.0
 conda install --yes -c conda-forge keras-applications
 
 # Compile TensorFlow


### PR DESCRIPTION
Newer versions of Bazel seem to be incompatible. Let's use the version specified in [Tested build configurations](https://www.tensorflow.org/install/source) section instead.

Ref https://github.com/hadim/docker-tensorflow-builder/issues/7, https://github.com/hadim/docker-tensorflow-builder/issues/8.