### PR TITLE
Add incompatible_remove_native_http_archive option to build

### DIFF
--- a/tensorflow/ubuntu-16.04/build.sh
+++ b/tensorflow/ubuntu-16.04/build.sh
@@ -87,6 +87,7 @@ if [ "$USE_GPU" -eq "1" ]; then
 else
 
 	bazel build --config=opt \
+					--incompatible_remove_native_http_archive=false \
 			    --action_env="LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" \
 			    //tensorflow/tools/pip_package:build_pip_package
 


### PR DESCRIPTION
# Problem 
I'm building a TensorFlow binary wheel for my specific hardware. When I run the process I get the following exception:

```
ERROR: error loading package '': Encountered error while reading extension file 'closure/defs.bzl': no such package '@io_bazel_rules_closure//closure': The native http_archive rule is deprecated. load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive") for a drop-in replacement.
Use --incompatible_remove_native_http_archive=false to temporarily continue using the native rule.
```

# Approach
I updated `build.sh` to include the suggested bazel flag

# Tested Environment
I ran into the issue and tested out a solution on a VM with the following CPU specs:
```
processor	: 7
vendor_id	: GenuineIntel
cpu family	: 15
model		: 6
model name	: Common KVM processor
stepping	: 1
microcode	: 0x1
cpu MHz		: 2399.996
cache size	: 4096 KB
physical id	: 7
siblings	: 1
core id		: 0
cpu cores	: 1
apicid		: 7
initial apicid	: 7
fpu		: yes
fpu_exception	: yes
cpuid level	: 5
wp		: yes
flags		: fpu de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 syscall nx lm constant_tsc nopl pni cx16 hypervisor kaiser
bugs		: cpu_meltdown spectre_v1 spectre_v2 spec_store_bypass l1tf
bogomips	: 4799.99
clflush size	: 64
cache_alignment	: 128
address sizes	: 46 bits physical, 48 bits virtual
power management:
```

I've run into this with Tensorflow version 1.9 as well as 1.12. 
I've only used the no GPU configuration so I don't know if it occurs there.
I've tried it with Python 3.5 and 3.6
