### PR TITLE
Improve example build in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ cd tensorflow/ubuntu-16.04/
 # or
 # cd tensorflow/centos-6.6/
 
-# Build the Docker image
-docker-compose build
-
 # Set env variables
 export PYTHON_VERSION=3.7
 export TF_VERSION_GIT_TAG=v1.13.1
 export BAZEL_VERSION=0.19
 export USE_GPU=0
+
+# Build the Docker image
+docker-compose build
 
 # Start the compilation
 docker-compose run tf
@@ -58,9 +58,6 @@ cd tensorflow/ubuntu-16.04/
 # or
 # cd tensorflow/centos-6.6/
 
-# Build the Docker image
-docker-compose build
-
 # Set env variables
 export PYTHON_VERSION=3.7
 export TF_VERSION_GIT_TAG=v1.13.1
@@ -68,6 +65,9 @@ export BAZEL_VERSION=0.19
 export USE_GPU=1
 export CUDA_VERSION=9.1
 export CUDNN_VERSION=7.1
+
+# Build the Docker image
+docker-compose build
 
 # Start the compilation
 docker-compose run tf

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ cd tensorflow/ubuntu-16.04/
 # cd tensorflow/centos-6.6/
 
 # Set env variables
-export PYTHON_VERSION=3.7
+export PYTHON_VERSION=3.6.7
 export TF_VERSION_GIT_TAG=v1.13.1
 export BAZEL_VERSION=0.19
 export USE_GPU=0
@@ -59,7 +59,7 @@ cd tensorflow/ubuntu-16.04/
 # cd tensorflow/centos-6.6/
 
 # Set env variables
-export PYTHON_VERSION=3.7
+export PYTHON_VERSION=3.6.7
 export TF_VERSION_GIT_TAG=v1.13.1
 export BAZEL_VERSION=0.19
 export USE_GPU=1

--- a/tensorflow/centos-6.6/build2.sh
+++ b/tensorflow/centos-6.6/build2.sh
@@ -49,6 +49,7 @@ export TF_NEED_GDR=0
 export TF_NEED_OPENCL_SYCL=0
 export TF_SET_ANDROID_WORKSPACE=0
 export TF_NEED_AWS=0
+export TF_NEED_IGNITE=0
 export TF_NEED_ROCM=0
 
 # Compiler options

--- a/tensorflow/centos-7.4/build2.sh
+++ b/tensorflow/centos-7.4/build2.sh
@@ -48,6 +48,7 @@ export TF_NEED_GDR=0
 export TF_NEED_OPENCL_SYCL=0
 export TF_SET_ANDROID_WORKSPACE=0
 export TF_NEED_AWS=0
+export TF_NEED_IGNITE=0
 export TF_NEED_ROCM=0
 
 # Compiler options

--- a/tensorflow/ubuntu-16.04/build.sh
+++ b/tensorflow/ubuntu-16.04/build.sh
@@ -54,6 +54,7 @@ export TF_NEED_GDR=0
 export TF_NEED_OPENCL_SYCL=0
 export TF_SET_ANDROID_WORKSPACE=0
 export TF_NEED_AWS=0
+export TF_NEED_IGNITE=0
 export TF_NEED_ROCM=0
 
 # Compiler options


### PR DESCRIPTION
Fix things I encountered when testing CentOS 7.4 images:

* Since there are no default values in `docker-compose.yml` for environment variables anymore, `docker-compose build` fails if you run it before setting our own values. Fixed the order in README.md to reflect that.
* I could not build TF v1.13.1 against Python 3.7.0, so let's set the version to 3.6.7 so that the example build works.
* Tensorflow 1.12.0 asks for Apache Ignite support interactively during build, I added a new env variable to prevent that.

<details>
<summary>Error I encountered when building TF 1.13.1 against Python 3.7.0</summary>

```
  File "/root/.cache/bazel/_bazel_root/68a62076e91007a7908bc42a32e4cff9/execroot/org_tensorflow/bazel-out/host/bin/tensorflow/create_tensorflow.pyt
hon_api_1_tf_python_api_gen_v1.runfiles/org_tensorflow/tensorflow/python/keras/datasets/imdb.py", line 25, in <module>
    from tensorflow.python.keras.preprocessing.sequence import _remove_long_seq
  File "/root/.cache/bazel/_bazel_root/68a62076e91007a7908bc42a32e4cff9/execroot/org_tensorflow/bazel-out/host/bin/tensorflow/create_tensorflow.pyt
hon_api_1_tf_python_api_gen_v1.runfiles/org_tensorflow/tensorflow/python/keras/preprocessing/__init__.py", line 30, in <module>
    from tensorflow.python.keras.preprocessing import image
  File "/root/.cache/bazel/_bazel_root/68a62076e91007a7908bc42a32e4cff9/execroot/org_tensorflow/bazel-out/host/bin/tensorflow/create_tensorflow.pyt
hon_api_1_tf_python_api_gen_v1.runfiles/org_tensorflow/tensorflow/python/keras/preprocessing/image.py", line 26, in <module>
    from scipy import ndimage  # pylint: disable=unused-import
  File "/conda/envs/tensorflow/lib/python3.7/site-packages/scipy/ndimage/__init__.py", line 161, in <module>
    from .filters import *
  File "/conda/envs/tensorflow/lib/python3.7/site-packages/scipy/ndimage/filters.py", line 38, in <module>
    from . import _ni_docstrings
  File "/conda/envs/tensorflow/lib/python3.7/site-packages/scipy/ndimage/_ni_docstrings.py", line 4, in <module>
    from scipy.misc import doccer
  File "/conda/envs/tensorflow/lib/python3.7/site-packages/scipy/misc/__init__.py", line 68, in <module>
    from scipy.interpolate._pade import pade as _pade
  File "/conda/envs/tensorflow/lib/python3.7/site-packages/scipy/interpolate/__init__.py", line 175, in <module>
    from .interpolate import *
  File "/conda/envs/tensorflow/lib/python3.7/site-packages/scipy/interpolate/interpolate.py", line 32, in <module>
    from .interpnd import _ndim_coords_from_arrays
  File "stringsource", line 105, in init scipy.interpolate.interpnd
AttributeError: type object 'scipy.interpolate.interpnd.array' has no attribute '__reduce_cython__'
Target //tensorflow/tools/pip_package:build_pip_package failed to build
Use --verbose_failures to see the command lines of failed build steps.
```

</details>