### PR TITLE
Fix CentOS 6.6 build

### DIFF
--- a/tensorflow/centos-6.6/Dockerfile
+++ b/tensorflow/centos-6.6/Dockerfile
@@ -12,7 +12,7 @@ RUN yum update -y && \
     gcc-c++ \
     which && \
     yum -y install centos-release-scl && \
-    yum -y install devtoolset-4-gcc devtoolset-4-gcc-c++ && \
+    yum -y install devtoolset-6-gcc devtoolset-6-gcc-c++ && \
     yum clean all
 
 # Install Anaconda

--- a/tensorflow/centos-6.6/build.sh
+++ b/tensorflow/centos-6.6/build.sh
@@ -7,6 +7,6 @@ if [ "$USE_GPU" -eq "1" ]; then
 	bash setup_cuda.sh
 fi
 
-# Enable GCC 5
+# Enable GCC 6
 chmod +x /build2.sh
-scl enable devtoolset-4 ./build2.sh
+scl enable devtoolset-6 ./build2.sh

--- a/tensorflow/centos-6.6/build2.sh
+++ b/tensorflow/centos-6.6/build2.sh
@@ -77,9 +77,6 @@ fi
 # Compilation
 ./configure
 
-mv /usr/bin/ld /usr/bin/ld_ori
-ln -s /opt/rh/devtoolset-6/root/usr/bin/ld /usr/bin/ld
-
 if [ "$USE_GPU" -eq "1" ]; then
 
 	bazel build --config=opt \
@@ -104,9 +101,6 @@ else
 
 	PACKAGE_NAME="tensorflow-${TF_VERSION_GIT_TAG}-py${PYTHON_VERSION}"
 fi
-
-rm -f /usr/bin/ld
-mv /usr/bin/ld_ori /usr/bin/ld
 
 # Project name can only be set for TF > 1.8
 bazel-bin/tensorflow/tools/pip_package/build_pip_package /wheels --project_name $PROJECT_NAME


### PR DESCRIPTION
On CentOS, the default version of GCC is 4.4.6, which is too old to build TensorFlow.

The script used to install GCC 5 instead (`devtoolset-4`), however, it's not available anymore: https://unix.stackexchange.com/a/477880

To fix the build, we can instead use GCC 6 (`devtoolset-6`).

Bug: https://github.com/hadim/docker-tensorflow-builder/issues/10 (already closed, but this is the proper fix).

@hadim