### PR TITLE
Fix unused variable, fix permissions

### DIFF
--- a/tensorflow/centos-6.6/build2.sh
+++ b/tensorflow/centos-6.6/build2.sh
@@ -103,7 +103,7 @@ else
 fi
 
 # Project name can only be set for TF > 1.8
-bazel-bin/tensorflow/tools/pip_package/build_pip_package /wheels --project_name $PROJECT_NAME
+bazel-bin/tensorflow/tools/pip_package/build_pip_package /wheels --project_name "$PACKAGE_NAME"
 
 # Use the following for TF <= 1.8
 #bazel-bin/tensorflow/tools/pip_package/build_pip_package /wheels

--- a/tensorflow/centos-6.6/build2.sh
+++ b/tensorflow/centos-6.6/build2.sh
@@ -88,7 +88,7 @@ if [ "$USE_GPU" -eq "1" ]; then
                 --action_env="LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" \
                 //tensorflow/tools/pip_package:build_pip_package
 
-    PACKAGE_NAME="tensorflow_gpu-${TF_VERSION_GIT_TAG}-py${PYTHON_VERSION}-cuda${TF_CUDA_VERSION}-cudnn${TF_CUDNN_VERSION}"
+    PACKAGE_NAME=tensorflow-gpu
 else
 
     bazel build --config=opt \
@@ -99,7 +99,7 @@ else
                 --action_env="LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" \
                 //tensorflow/tools/pip_package:build_pip_package
 
-    PACKAGE_NAME="tensorflow-${TF_VERSION_GIT_TAG}-py${PYTHON_VERSION}"
+    PACKAGE_NAME=tensorflow
 fi
 
 # Project name can only be set for TF > 1.8

--- a/tensorflow/centos-6.6/build2.sh
+++ b/tensorflow/centos-6.6/build2.sh
@@ -109,4 +109,4 @@ bazel-bin/tensorflow/tools/pip_package/build_pip_package /wheels --project_name 
 #bazel-bin/tensorflow/tools/pip_package/build_pip_package /wheels
 
 # Fix wheel folder permissions
-chmod -R 777 /wheels/
+chmod -R 666 /wheels/

--- a/tensorflow/centos-6.6/build2.sh
+++ b/tensorflow/centos-6.6/build2.sh
@@ -89,6 +89,7 @@ if [ "$USE_GPU" -eq "1" ]; then
                 //tensorflow/tools/pip_package:build_pip_package
 
     PACKAGE_NAME=tensorflow-gpu
+    SUBFOLDER_NAME="${TF_VERSION_GIT_TAG}-py${PYTHON_VERSION}-cuda${TF_CUDA_VERSION}-cudnn${TF_CUDNN_VERSION}"
 else
 
     bazel build --config=opt \
@@ -100,13 +101,16 @@ else
                 //tensorflow/tools/pip_package:build_pip_package
 
     PACKAGE_NAME=tensorflow
+    SUBFOLDER_NAME="${TF_VERSION_GIT_TAG}-py${PYTHON_VERSION}"
 fi
 
+mkdir -p "/wheels/$SUBFOLDER_NAME"
+
 # Project name can only be set for TF > 1.8
-bazel-bin/tensorflow/tools/pip_package/build_pip_package /wheels --project_name "$PACKAGE_NAME"
+bazel-bin/tensorflow/tools/pip_package/build_pip_package "/wheels/$SUBFOLDER_NAME" --project_name "$PACKAGE_NAME"
 
 # Use the following for TF <= 1.8
-#bazel-bin/tensorflow/tools/pip_package/build_pip_package /wheels
+#bazel-bin/tensorflow/tools/pip_package/build_pip_package "/wheels/$SUBFOLDER_NAME"
 
 # Fix wheel folder permissions
 chmod -R 666 /wheels/

--- a/tensorflow/centos-7.4/build2.sh
+++ b/tensorflow/centos-7.4/build2.sh
@@ -93,7 +93,7 @@ else
 fi
 
 # Project name can only be set for TF > 1.8
-bazel-bin/tensorflow/tools/pip_package/build_pip_package /wheels --project_name $PROJECT_NAME
+bazel-bin/tensorflow/tools/pip_package/build_pip_package /wheels --project_name "$PACKAGE_NAME"
 
 # Use the following for TF <= 1.8
 #bazel-bin/tensorflow/tools/pip_package/build_pip_package /wheels

--- a/tensorflow/centos-7.4/build2.sh
+++ b/tensorflow/centos-7.4/build2.sh
@@ -82,14 +82,14 @@ if [ "$USE_GPU" -eq "1" ]; then
                 --action_env="LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" \
                 //tensorflow/tools/pip_package:build_pip_package
 
-    PACKAGE_NAME="tensorflow_gpu-${TF_VERSION_GIT_TAG}-py${PYTHON_VERSION}-cuda${TF_CUDA_VERSION}-cudnn${TF_CUDNN_VERSION}"
+    PACKAGE_NAME=tensorflow-gpu
 else
 
     bazel build --config=opt \
                 --action_env="LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" \
                 //tensorflow/tools/pip_package:build_pip_package
 
-    PACKAGE_NAME="tensorflow-${TF_VERSION_GIT_TAG}-py${PYTHON_VERSION}"
+    PACKAGE_NAME=tensorflow
 fi
 
 # Project name can only be set for TF > 1.8

--- a/tensorflow/centos-7.4/build2.sh
+++ b/tensorflow/centos-7.4/build2.sh
@@ -83,6 +83,7 @@ if [ "$USE_GPU" -eq "1" ]; then
                 //tensorflow/tools/pip_package:build_pip_package
 
     PACKAGE_NAME=tensorflow-gpu
+    SUBFOLDER_NAME="${TF_VERSION_GIT_TAG}-py${PYTHON_VERSION}-cuda${TF_CUDA_VERSION}-cudnn${TF_CUDNN_VERSION}"
 else
 
     bazel build --config=opt \
@@ -90,13 +91,16 @@ else
                 //tensorflow/tools/pip_package:build_pip_package
 
     PACKAGE_NAME=tensorflow
+    SUBFOLDER_NAME="${TF_VERSION_GIT_TAG}-py${PYTHON_VERSION}"
 fi
 
+mkdir -p "/wheels/$SUBFOLDER_NAME"
+
 # Project name can only be set for TF > 1.8
-bazel-bin/tensorflow/tools/pip_package/build_pip_package /wheels --project_name "$PACKAGE_NAME"
+bazel-bin/tensorflow/tools/pip_package/build_pip_package "/wheels/$SUBFOLDER_NAME" --project_name "$PACKAGE_NAME"
 
 # Use the following for TF <= 1.8
-#bazel-bin/tensorflow/tools/pip_package/build_pip_package /wheels
+#bazel-bin/tensorflow/tools/pip_package/build_pip_package "/wheels/$SUBFOLDER_NAME"
 
 # Fix wheel folder permissions
 chmod -R 666 /wheels/

--- a/tensorflow/centos-7.4/build2.sh
+++ b/tensorflow/centos-7.4/build2.sh
@@ -99,4 +99,4 @@ bazel-bin/tensorflow/tools/pip_package/build_pip_package /wheels --project_name 
 #bazel-bin/tensorflow/tools/pip_package/build_pip_package /wheels
 
 # Fix wheel folder permissions
-chmod -R 777 /wheels/
+chmod -R 666 /wheels/

--- a/tensorflow/ubuntu-16.04/build.sh
+++ b/tensorflow/ubuntu-16.04/build.sh
@@ -88,14 +88,14 @@ if [ "$USE_GPU" -eq "1" ]; then
                 --action_env="LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" \
                 //tensorflow/tools/pip_package:build_pip_package
 
-    PACKAGE_NAME="tensorflow_gpu-${TF_VERSION_GIT_TAG}-py${PYTHON_VERSION}-cuda${TF_CUDA_VERSION}-cudnn${TF_CUDNN_VERSION}"
+    PACKAGE_NAME=tensorflow-gpu
 else
 
     bazel build --config=opt \
                 --action_env="LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" \
                 //tensorflow/tools/pip_package:build_pip_package
 
-    PACKAGE_NAME="tensorflow-${TF_VERSION_GIT_TAG}-py${PYTHON_VERSION}"
+    PACKAGE_NAME=tensorflow
 fi
 
 # Project name can only be set for TF > 1.8

--- a/tensorflow/ubuntu-16.04/build.sh
+++ b/tensorflow/ubuntu-16.04/build.sh
@@ -89,6 +89,7 @@ if [ "$USE_GPU" -eq "1" ]; then
                 //tensorflow/tools/pip_package:build_pip_package
 
     PACKAGE_NAME=tensorflow-gpu
+    SUBFOLDER_NAME="${TF_VERSION_GIT_TAG}-py${PYTHON_VERSION}-cuda${TF_CUDA_VERSION}-cudnn${TF_CUDNN_VERSION}"
 else
 
     bazel build --config=opt \
@@ -96,13 +97,16 @@ else
                 //tensorflow/tools/pip_package:build_pip_package
 
     PACKAGE_NAME=tensorflow
+    SUBFOLDER_NAME="${TF_VERSION_GIT_TAG}-py${PYTHON_VERSION}"
 fi
 
+mkdir -p "/wheels/$SUBFOLDER_NAME"
+
 # Project name can only be set for TF > 1.8
-bazel-bin/tensorflow/tools/pip_package/build_pip_package /wheels --project_name "$PACKAGE_NAME"
+bazel-bin/tensorflow/tools/pip_package/build_pip_package "/wheels/$SUBFOLDER_NAME" --project_name "$PACKAGE_NAME"
 
 # Use the following for TF <= 1.8
-#bazel-bin/tensorflow/tools/pip_package/build_pip_package /wheels
+#bazel-bin/tensorflow/tools/pip_package/build_pip_package "/wheels/$SUBFOLDER_NAME"
 
 # Fix wheel folder permissions
 chmod -R 666 /wheels/

--- a/tensorflow/ubuntu-16.04/build.sh
+++ b/tensorflow/ubuntu-16.04/build.sh
@@ -99,7 +99,7 @@ else
 fi
 
 # Project name can only be set for TF > 1.8
-bazel-bin/tensorflow/tools/pip_package/build_pip_package /wheels --project_name $PROJECT_NAME
+bazel-bin/tensorflow/tools/pip_package/build_pip_package /wheels --project_name "$PACKAGE_NAME"
 
 # Use the following for TF <= 1.8
 #bazel-bin/tensorflow/tools/pip_package/build_pip_package /wheels

--- a/tensorflow/ubuntu-16.04/build.sh
+++ b/tensorflow/ubuntu-16.04/build.sh
@@ -105,4 +105,4 @@ bazel-bin/tensorflow/tools/pip_package/build_pip_package /wheels --project_name 
 #bazel-bin/tensorflow/tools/pip_package/build_pip_package /wheels
 
 # Fix wheel folder permissions
-chmod -R 777 /wheels/
+chmod -R 666 /wheels/


### PR DESCRIPTION
- `PACKAGE_NAME` variable was left unused.
- Wheels don't need to be executable, so `rw-` permissions will suffice.
- Use standard names for packages so that they can be used as drop-in replacements for those from PyPI.