### PR TITLE
Fix missing clock_gettime symbol

### DIFF
--- a/tensorflow/centos-7.4/build2.sh
+++ b/tensorflow/centos-7.4/build2.sh
@@ -79,6 +79,10 @@ if [ "$USE_GPU" -eq "1" ]; then
 
     bazel build --config=opt \
                 --config=cuda \
+                --linkopt="-lrt" \
+                --linkopt="-lm" \
+                --host_linkopt="-lrt" \
+                --host_linkopt="-lm" \
                 --action_env="LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" \
                 //tensorflow/tools/pip_package:build_pip_package
 
@@ -86,6 +90,10 @@ if [ "$USE_GPU" -eq "1" ]; then
 else
 
     bazel build --config=opt \
+                --linkopt="-lrt" \
+                --linkopt="-lm" \
+                --host_linkopt="-lrt" \
+                --host_linkopt="-lm" \
                 --action_env="LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" \
                 //tensorflow/tools/pip_package:build_pip_package
 

--- a/tensorflow/ubuntu-16.04/build.sh
+++ b/tensorflow/ubuntu-16.04/build.sh
@@ -85,6 +85,10 @@ if [ "$USE_GPU" -eq "1" ]; then
 
     bazel build --config=opt \
                 --config=cuda \
+                --linkopt="-lrt" \
+                --linkopt="-lm" \
+                --host_linkopt="-lrt" \
+                --host_linkopt="-lm" \
                 --action_env="LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" \
                 //tensorflow/tools/pip_package:build_pip_package
 
@@ -92,6 +96,10 @@ if [ "$USE_GPU" -eq "1" ]; then
 else
 
     bazel build --config=opt \
+                --linkopt="-lrt" \
+                --linkopt="-lm" \
+                --host_linkopt="-lrt" \
+                --host_linkopt="-lm" \
                 --action_env="LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" \
                 //tensorflow/tools/pip_package:build_pip_package
 


### PR DESCRIPTION
Weirdly enough, these linker flags are necessary to build TensorFlow v1.13.1. Older versions could be built without them. 🤷‍♂️

@hadim 