### PR TITLE
Fix TensorFlow 2.0 builds on CentOS

### DIFF
--- a/tensorflow/centos-6.6/build2.sh
+++ b/tensorflow/centos-6.6/build2.sh
@@ -8,6 +8,7 @@ conda config --add channels conda-forge
 conda create --yes -n tensorflow python==$PYTHON_VERSION
 source activate tensorflow
 conda install --yes numpy wheel bazel==$BAZEL_VERSION
+conda install --yes git
 pip install keras-applications keras-preprocessing
 
 # Compile TensorFlow
@@ -18,11 +19,10 @@ pip install keras-applications keras-preprocessing
 
 cd /
 rm -fr tensorflow/
-git clone --depth 1 "https://github.com/tensorflow/tensorflow.git"
+git clone --depth 1 --branch $TF_VERSION_GIT_TAG "https://github.com/tensorflow/tensorflow.git"
 
 TF_ROOT=/tensorflow
 cd $TF_ROOT
-git checkout $TF_VERSION_GIT_TAG
 
 # Python path options
 export PYTHON_BIN_PATH=$(which python)

--- a/tensorflow/centos-7.4/build2.sh
+++ b/tensorflow/centos-7.4/build2.sh
@@ -8,6 +8,7 @@ conda config --add channels conda-forge
 conda create --yes -n tensorflow python==$PYTHON_VERSION
 source activate tensorflow
 conda install --yes numpy wheel bazel==$BAZEL_VERSION
+conda install --yes git
 pip install keras-applications keras-preprocessing
 
 # Compile TensorFlow


### PR DESCRIPTION
CentOS images have very old versions of Git. During the build of TF 2.0, `git` gets invoked a few times with an unsupported option. Installing Git with Conda fixes the issue.

I've also built TF 1.14.0 with the same script, so older versions seem to still work.

```sh
# The options I've used:
export PYTHON_VERSION=3.6.9
export TF_VERSION_GIT_TAG=v2.0.0
export BAZEL_VERSION=0.26.1
export USE_GPU=0
```